### PR TITLE
 Allow all routing on the webapp #503 

### DIFF
--- a/src/main/resources/webapp/webapp.js
+++ b/src/main/resources/webapp/webapp.js
@@ -59,16 +59,7 @@ router.get("/manifest.json", function(req) {
 router.route(
     'GET',
     [
-        "/leagues/{name}",
-        "/leagues/{name}/players",
-        "/leagues/{name}/teams",
-        "/leagues/{name}/games",
-        "/players/{name}/edit",
-        "/players/{name}",
-        "/teams/{name}",
-        "/games/{id}",
-        "/{path}",
-        "/",
+        ".*",
         "",
     ],
     defaultRoute


### PR DESCRIPTION
Routing all 404 pages is inconvenient, so passing everything to angular. 
They will be redirected to root page if it cant render the current path.