### PR TITLE
Bump version to 4.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ projectName = officeleague
 appName = com.enonic.app.officeleague
 xpVersion = 8.0.0-B4
 
-version=3.2.3-SNAPSHOT
+version=4.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bump `version` in `gradle.properties` from `3.2.3-SNAPSHOT` to `4.0.0-SNAPSHOT` for the XP 8 line.
- Add `releaseBranch:` config in `.github/workflows/enonic-gradle.yml` listing both `master` and `3.x`, so pushes to either branch are recognized as release-branch builds by `enonic/release-tools/build-and-publish`.

The XP 7 maintenance line continues on the new [`3.x`](https://github.com/enonic/app-office-league/tree/3.x) branch (created at the post-release SNAPSHOT commit `ef7b0ae`, where `gradle.properties` was already at `3.2.2-SNAPSHOT`). A companion PR against `3.x` adds the same `releaseBranch:` block there.

Reference pattern: app-booster `master` vs `1.x`.

## Test plan

- [ ] CI build on `chore/bump-to-next-major` is green
- [ ] After merge: `./gradlew clean build` from master is green