### PR TITLE
Add release-branch CI config for 3.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `releaseBranch:` block in `.github/workflows/enonic-gradle.yml` listing both `master` and `3.x`, so pushes to `3.x` are recognized as release-branch builds by `enonic/release-tools/build-and-publish` (the action reads `releaseBranch:` from the branch's own workflow file).
- No version bump; no other changes. Per app-booster's reference (master vs 1.x), this is the only edit required on the maintenance branch.

The companion PR against `master` (#1796) bumps the version to `4.0.0-SNAPSHOT` and applies the same `releaseBranch:` block there.

## Test plan

- [ ] CI run on the working branch is green
- [ ] After merge: a CI run on `3.x` classifies it as a release branch