### PR TITLE
Drop unused lib-util dep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     include libs.lib.thymeleaf
     include libs.lib.mustache
     include libs.lib.http.client
-    include libs.lib.util
     include libs.lib.graphql
     include libs.lib.geoip
     include libs.lib.text.encoding

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ router = "3.2.0"
 thymeleaf = "3.0.0-SNAPSHOT"
 mustache = "2.1.1"
 http-client = "3.2.2"
-util = "3.1.1"
 graphql = "2.1.0"
 geoip = "2.1.0"
 text-encoding = "2.1.1"
@@ -14,7 +13,6 @@ lib-router        = { module = "com.enonic.lib:lib-router",        version.ref =
 lib-thymeleaf     = { module = "com.enonic.lib:lib-thymeleaf",     version.ref = "thymeleaf" }
 lib-mustache      = { module = "com.enonic.lib:lib-mustache",      version.ref = "mustache" }
 lib-http-client   = { module = "com.enonic.lib:lib-http-client",   version.ref = "http-client" }
-lib-util          = { module = "com.enonic.lib:lib-util",          version.ref = "util" }
 lib-graphql       = { module = "com.enonic.lib:lib-graphql",       version.ref = "graphql" }
 lib-geoip         = { module = "com.enonic.lib:lib-geoip",         version.ref = "geoip" }
 lib-text-encoding = { module = "com.enonic.lib:lib-text-encoding", version.ref = "text-encoding" }

--- a/src/main/resources/webapp/controllers/image-helper.js
+++ b/src/main/resources/webapp/controllers/image-helper.js
@@ -1,6 +1,5 @@
 var imageLib = require("/lib/image");
 var contextLib = require("/lib/xp/context");
-const util = require("/lib/util");
 
 exports.processImage = function (node, attachment, params) {
     if (!isProcessableImage(attachment.mimeType)) {

--- a/src/main/resources/webapp/controllers/player-image.js
+++ b/src/main/resources/webapp/controllers/player-image.js
@@ -2,7 +2,6 @@ const storeLib = require("/lib/office-league-store");
 const attachmentLib = require("/lib/attachment");
 const ioLib = require("/lib/xp/io");
 const imageHelper = require("./image-helper");
-const util = require("/lib/util");
 
 const defaultImage = ioLib
     .getResource("/assets/img/default-images/account.svg")


### PR DESCRIPTION
## Summary

`lib-util` was declared in `build.gradle` / `gradle/libs.versions.toml` and `require()`d at the top of two webapp controllers, but `util.*` is never actually referenced anywhere.

Dropped:
- `src/main/resources/webapp/controllers/image-helper.js` — `const util = require("/lib/util");`
- `src/main/resources/webapp/controllers/player-image.js` — `const util = require("/lib/util");`
- `build.gradle` — `include libs.lib.util`
- `gradle/libs.versions.toml` — `util` version + `lib-util` library entries

Verified: `grep -rn '/lib/util' src/` returns nothing after the edits. (Other `util.*` hits in the repo are `Java.type('java.util.UUID')`-style — unrelated.)

No behavior change.

## Test plan

- [x] `./gradlew build` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)