### PR TITLE
Migrate to lib-asset #1805

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     include libs.lib.geoip
     include libs.lib.text.encoding
     include libs.lib.notifications
+    include libs.lib.asset
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ graphql = "3.0.0-SNAPSHOT"
 geoip = "3.0.0-SNAPSHOT"
 text-encoding = "3.0.0-SNAPSHOT"
 notifications = "3.0.0-SNAPSHOT"
+asset = "2.0.0-SNAPSHOT"
 
 [libraries]
 lib-router        = { module = "com.enonic.lib:lib-router",        version.ref = "router" }
@@ -17,3 +18,4 @@ lib-graphql       = { module = "com.enonic.lib:lib-graphql",       version.ref =
 lib-geoip         = { module = "com.enonic.lib:lib-geoip",         version.ref = "geoip" }
 lib-text-encoding = { module = "com.enonic.lib:lib-text-encoding", version.ref = "text-encoding" }
 lib-notifications = { module = "com.enonic.lib:lib-notifications", version.ref = "notifications" }
+lib-asset         = { module = "com.enonic.lib:lib-asset",         version.ref = "asset" }

--- a/src/main/resources/lib/pwa/manifest-controller.js
+++ b/src/main/resources/lib/pwa/manifest-controller.js
@@ -1,4 +1,4 @@
-var portalLib = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var mustache = require('/lib/mustache');
 
 exports.get = function(req) {
@@ -7,7 +7,7 @@ exports.get = function(req) {
 
     var params = {
         startUrl,
-        iconUrl : portalLib.assetUrl({path: '/icons'})
+        iconUrl : assetLib.assetUrl({path: '/icons'})
     };
     var res = mustache.render(resolve('manifest.json'), params);
 

--- a/src/main/resources/webapp/webapp.yaml
+++ b/src/main/resources/webapp/webapp.yaml
@@ -1,0 +1,3 @@
+kind: "WebApp"
+apis:
+  - "asset"


### PR DESCRIPTION
Closes #1805

`portal.assetUrl` is deprecated in lib-portal — `Use libAsset or libStatic instead. This function will be removed in future versions.` This app's only remaining call site (`lib/pwa/manifest-controller.js`, served from the webapp via `/manifest.json`) migrates to **lib-asset**. lib-asset works in Site, WebApp, and AdminTool descriptors, which fits this app's webapp context.

## What changed

- `gradle/libs.versions.toml` — register `lib-asset = 2.0.0-SNAPSHOT`.
- `build.gradle` — `include libs.lib.asset`.
- `src/main/resources/webapp/webapp.yaml` (new) — `apis: ["asset"]`. lib-asset is a Universal API and must be mounted explicitly per descriptor.
- `src/main/resources/lib/pwa/manifest-controller.js` — replace `portalLib.assetUrl({path: '/icons'})` with `assetLib.assetUrl({path: '/icons'})` (and swap `require('/lib/xp/portal')` → `require('/lib/enonic/asset')`, since no other `portal.*` calls remain in this file).

Out of scope: `src/main/resources/cms/old/marketing-page/marketing-page.html` and `cms/old/offline/offline.html` also reference `portal.assetUrl`, but `cms/old/` is not a recognized XP resource path — these are unused historical files preserved in-tree and won't be deployed.

## Test plan

Verified end-to-end against XP 8 snapshot:

- [x] `./gradlew build --refresh-dependencies` clean (BUILD SUCCESSFUL).
- [x] Bundle reaches ACTIVE: `Started application com.enonic.app.officeleague bundle 117`.
- [x] `GET /webapp/com.enonic.app.officeleague/manifest.json` returns HTTP 200 with the rendered manifest. Generated `icons[].src` now follows the lib-asset pattern `/webapp/<app>/_/<app>:asset/<fingerprint>/icons/<file>`.
- [x] `GET /webapp/.../_/com.enonic.app.officeleague:asset/<fingerprint>/icons/android-chrome-192x192.png` → HTTP 200, `image/png`, 14540 bytes (matches the file on disk).
- [x] Same for `android-chrome-512x512.png` → HTTP 200, 38797 bytes.